### PR TITLE
Add support for cli login for storage plugin

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -22,7 +22,7 @@
       "command": "./.vscode/scripts/runporterinbackground.sh",
       "options": {
         "env": {
-          "PORTER_RUN_PLUGIN_IN_DEBUGGER": "secrets.azure.keyvault",
+          "PORTER_RUN_PLUGIN_IN_DEBUGGER": "storage.azure.blob",
           "PORTER_PLUGIN_WORKING_DIRECTORY": "${workspaceRoot}/cmd/azure",
           "PORTER_DEBUGGER_PORT": "2345",
           "PORTER_HOME": "/home/${env:USER}/.porter"

--- a/README.md
+++ b/README.md
@@ -23,19 +23,44 @@ Storage plugins allow Porter to store data, such as claims, parameters and crede
 
 ### Blob
 
-The `azure.blob` plugin stores data in Azure Blob Storage. 
+The `azure.blob` plugin stores data in Azure Blob Storage. The plugin requires a storage account name and storage account key. This can be provided as a connection string in an environment variable or can be looked up at run time if the user is logged in with the Azure CLI.
 
+1. [Create a storage account][account]
+1. [Create a container][container] named `porter`.
 1. Open, or create, `~/.porter/config.toml`.
+
+#### Use a connection string
+
 1. Add the following line to activate the Azure blob storage plugin:
 
     ```toml
     default-storage-plugin = "azure.blob"
     ```
-
-1. [Create a storage account][account]
-1. [Create a container][container] named `porter`.
 1. [Copy the connection string][connstring] for the storage account. Then set it as an environment variable named 
     `AZURE_STORAGE_CONNECTION_STRING`.
+
+#### Use the Azure CLI
+
+1. Add the following lines to activate the Azure blob storage plugin and configure storage account details:
+
+    ```toml
+    default-storage = "azureblob"
+
+    [[storage]]
+    name = "azureblob"
+    plugin = "azure.blob"
+
+    [storage.config]
+    account="storage account name"
+    resourcegroup="storage account resource group"
+
+    ```
+
+If the machine you are using is already logged in with the Azure CLI then the same security context will be used to lookup the keys for the storage account, by default it will use the current subscription (the one returned by the command `az account show`), to set the subscription explicitly add the following line to the `[storage.config]`.
+
+ ```toml
+ subscriptionId="storage account subscription id"
+ ```
 
 ## Secrets
 

--- a/README.md
+++ b/README.md
@@ -52,14 +52,14 @@ The `azure.blob` plugin stores data in Azure Blob Storage. The plugin requires a
 
     [storage.config]
     account="storage account name"
-    resourcegroup="storage account resource group"
+    resource-group="storage account resource group"
 
     ```
 
-If the machine you are using is already logged in with the Azure CLI then the same security context will be used to lookup the keys for the storage account, by default it will use the current subscription (the one returned by the command `az account show`), to set the subscription explicitly add the following line to the `[storage.config]`.
+If the machine you are using is already logged in with the Azure CLI, then the same security context will be used to lookup the keys for the storage account. By default it will use the current subscription (the one returned by the command `az account show`). To set the subscription explicitly add the following line to the `[storage.config]`.
 
  ```toml
- subscriptionId="storage account subscription id"
+ subscription-id="storage account subscription id"
  ```
 
 ## Secrets

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/Azure/go-autorest/autorest v0.11.2
 	github.com/Azure/go-autorest/autorest/adal v0.9.0
 	github.com/Azure/go-autorest/autorest/azure/auth v0.5.0
+	github.com/Azure/go-autorest/autorest/azure/cli v0.4.0
 	github.com/Azure/go-autorest/autorest/to v0.4.0 // indirect
 	github.com/Azure/go-autorest/autorest/validation v0.3.0 // indirect
 	github.com/cnabio/cnab-go v0.13.4-0.20200817181428-9005c1da4354

--- a/pkg/azure/azureconfig/config.go
+++ b/pkg/azure/azureconfig/config.go
@@ -6,14 +6,14 @@ type Config struct {
 	// string should be loaded.
 	EnvConnectionString string `json:"env"`
 
-	// StorageAccount contains the name of the storage account to be used by the Azure storage plugin, if the azure connection environment variable is not set this and StorageAccountResourceGroup are populated and the user is logged in with the Azure CLI
+	// StorageAccount contains the name of the storage account to be used by the Azure storage plugin, if the azure connection environment variable is not set and this proeprty and StorageAccountResourceGroup are populated and the user is logged in with the Azure CLI
 	// the Storage Account Key will be looked up at runtime using the logged in users credentials
 	StorageAccount string `json:"account"`
-	// StorageAccountResourceGroup contains the name of the storage account to be used by the Azure storage plugin, if the azure connection environment variable is not set this and StorageAccount are populated and the user is logged in with the Azure CLI
+	// StorageAccountResourceGroup contains the name of the resource group containing the storage account to be used by the Azure storage plugin, if the azure connection environment variable is not set and this property and StorageAccount are populated and the user is logged in with the Azure CLI
 	// the Storage Account Key will be looked up at runtime using the logged in users credentials
-	StorageAccountResourceGroup string `json:"resourcegroup"`
-	// StorageAccountSubscriptionId contains the subscriptionId of the subscription to be used when looking up the Storage Account Key, if this is not set then the current CLI subscription will be used
-	StorageAccountSubscriptionId string `json:"subscriptionId"`
+	StorageAccountResourceGroup string `json:"resource-group"`
+	// StorageAccountSubscriptionId contains the subscription id of the subscription to be used when looking up the Storage Account Key, if this is not set then the current CLI subscription will be used
+	StorageAccountSubscriptionId string `json:"subscription-id"`
 
 	// EnvAzurePrefix is the prefix applied to every azure
 	// environment variable For example, for a prefix of "DEV_AZURE_", the

--- a/pkg/azure/azureconfig/config.go
+++ b/pkg/azure/azureconfig/config.go
@@ -6,6 +6,15 @@ type Config struct {
 	// string should be loaded.
 	EnvConnectionString string `json:"env"`
 
+	// StorageAccount contains the name of the storage account to be used by the Azure storage plugin, if the azure connection environment variable is not set this and StorageAccountResourceGroup are populated and the user is logged in with the Azure CLI
+	// the Storage Account Key will be looked up at runtime using the logged in users credentials
+	StorageAccount string `json:"account"`
+	// StorageAccountResourceGroup contains the name of the storage account to be used by the Azure storage plugin, if the azure connection environment variable is not set this and StorageAccount are populated and the user is logged in with the Azure CLI
+	// the Storage Account Key will be looked up at runtime using the logged in users credentials
+	StorageAccountResourceGroup string `json:"resourcegroup"`
+	// StorageAccountSubscriptionId contains the subscriptionId of the subscription to be used when looking up the Storage Account Key, if this is not set then the current CLI subscription will be used
+	StorageAccountSubscriptionId string `json:"subscriptionId"`
+
 	// EnvAzurePrefix is the prefix applied to every azure
 	// environment variable For example, for a prefix of "DEV_AZURE_", the
 	// variables would be "DEV_AZURE_TENANT_ID", "DEV_AZURE_CLIENT_ID",

--- a/pkg/azure/blob/credentials.go
+++ b/pkg/azure/blob/credentials.go
@@ -53,7 +53,7 @@ func GetCredentials(cfg azureconfig.Config, l hclog.Logger) (CredentialSet, erro
 			return CredentialSet{}, errors.Errorf("environment variable %s containing the azure storage connection string was not set:\n%#v", credsEnv, cfg)
 		}
 		if err != nil {
-			return CredentialSet{}, errors.Errorf("%v:%#v", err, cfg)
+			return CredentialSet{}, errors.Errorf("%v\n%#v", err, cfg)
 		}
 		return cred, nil
 	}

--- a/pkg/azure/blob/credentials.go
+++ b/pkg/azure/blob/credentials.go
@@ -1,12 +1,21 @@
 package blob
 
 import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
 	"os"
+	"path"
 	"regexp"
+	"strings"
 
 	"get.porter.sh/plugin/azure/pkg/azure/azureconfig"
+
 	"github.com/Azure/azure-pipeline-go/pipeline"
+	"github.com/Azure/azure-sdk-for-go/profiles/latest/storage/mgmt/storage"
 	"github.com/Azure/azure-storage-blob-go/azblob"
+	"github.com/Azure/go-autorest/autorest/azure/auth"
 	"github.com/hashicorp/go-hclog"
 	"github.com/pkg/errors"
 )
@@ -17,6 +26,18 @@ type CredentialSet struct {
 }
 
 const ConnectionEnvironmentVariable = "AZURE_STORAGE_CONNECTION_STRING"
+const PublicCloud = "AzureCloud"
+const AzureDirectory = ".azure"
+const AzureProile = "azureProfile.json"
+const UserAgent = "porter.azure.storage.plugin"
+const BOM = '\uFEFF'
+
+type AvailableSubscription struct {
+	SubscriptionId  string `json:"id"`
+	State           string `json:"state"`
+	IsDefault       bool   `json:"isDefault"`
+	EnvironmentName string `json:"environmentName"`
+}
 
 func GetCredentials(cfg azureconfig.Config, l hclog.Logger) (CredentialSet, error) {
 	var credsEnv = cfg.EnvConnectionString
@@ -26,7 +47,11 @@ func GetCredentials(cfg azureconfig.Config, l hclog.Logger) (CredentialSet, erro
 
 	connString := os.Getenv(credsEnv)
 	if connString == "" {
-		return CredentialSet{}, errors.Errorf("environment variable %s containing the azure storage connection string was not set\n%#v", credsEnv, cfg)
+		cred, err := GetCredentialsFromCli(cfg, l)
+		if err != nil {
+			return CredentialSet{}, errors.Errorf("environment variable %s containing the azure storage connection string was not set: %v\n%#v", credsEnv, err, cfg)
+		}
+		return cred, nil
 	}
 
 	accountName, accountKey, err := parseConnectionString(connString)
@@ -43,6 +68,113 @@ func GetCredentials(cfg azureconfig.Config, l hclog.Logger) (CredentialSet, erro
 	return CredentialSet{Credential: *cred, Pipeline: pipe}, nil
 }
 
+func GetCredentialsFromCli(cfg azureconfig.Config, l hclog.Logger) (CredentialSet, error) {
+
+	if len(cfg.StorageAccount) == 0 || len(cfg.StorageAccountResourceGroup) == 0 {
+		return CredentialSet{}, errors.Errorf("StorageAccount and/or StorageAccountResourceGroup was not set, login with az cli not attempted")
+	}
+
+	authorizer, err := auth.NewAuthorizerFromCLI()
+	if err != nil {
+		return CredentialSet{}, errors.Errorf("Failed to login with Azure cli: %v", err)
+	}
+	subscriptionId := cfg.StorageAccountSubscriptionId
+	if len(subscriptionId) == 0 {
+		subscriptionId, err = getCurrentAzureSubscriptionFromCli()
+		if err != nil {
+			return CredentialSet{}, err
+		}
+	}
+	accountsClient := storage.NewAccountsClient(subscriptionId)
+	accountsClient.Authorizer = authorizer
+	_ = accountsClient.AddToUserAgent(UserAgent)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	result, err := accountsClient.ListKeys(ctx, cfg.StorageAccountResourceGroup, cfg.StorageAccount, "")
+	if err != nil {
+		return CredentialSet{}, errors.Errorf("Failed to get storage account keys: %v", err)
+	}
+	cred, err := azblob.NewSharedKeyCredential(cfg.StorageAccount, *(((*result.Keys)[0]).Value))
+	if err != nil {
+		return CredentialSet{}, errors.Errorf("Failed to create storage account credential: %v", err)
+	}
+	pipe := azblob.NewPipeline(cred, azblob.PipelineOptions{})
+	return CredentialSet{Credential: *cred, Pipeline: pipe}, nil
+
+}
+
+func getCurrentAzureSubscriptionFromCli() (string, error) {
+	var subscription AvailableSubscription
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("Error getting home directory: %w", err)
+	}
+	file, err := os.Open(path.Join(home, AzureDirectory, AzureProile))
+	if err != nil {
+		return "", fmt.Errorf("Error getting azure profile: %w", err)
+	}
+	defer file.Close()
+
+	// azureProfile can have BOM and embedded BOM so use decoder and check for BOM rather than unmarshall
+
+	reader := bufio.NewReader(file)
+	if err := removeBOM(reader); err != nil {
+		return "", err
+	}
+
+	decoder := json.NewDecoder(reader)
+	if _, err := decoder.Token(); err != nil {
+		return "", fmt.Errorf("Error decoding opening json token: %w", err)
+	}
+
+	property, err := decoder.Token()
+	if err != nil {
+		return "", fmt.Errorf("Error decoding subscriptions token: %w", err)
+	}
+	if val, ok := property.(string); !ok || !strings.EqualFold(val, "subscriptions") {
+		return "", fmt.Errorf("Error gettting subscriptions property: %w", err)
+	}
+
+	delim, err := decoder.Token()
+	if err != nil {
+		return "", fmt.Errorf("Error decoding json array delimiter: %w", err)
+	}
+	if _, ok := delim.(json.Delim); !ok {
+		return "", fmt.Errorf("Error getting array delimiter: %w", err)
+	}
+
+	for decoder.More() {
+
+		// azureProfile can have embedded BOM
+
+		if err := removeBOM(reader); err != nil {
+			return "", err
+		}
+
+		if err := decoder.Decode(&subscription); err != nil {
+			return "", fmt.Errorf("Error decoding json: %w", err)
+		}
+
+		if subscription.EnvironmentName == PublicCloud && subscription.IsDefault {
+			return subscription.SubscriptionId, nil
+		}
+	}
+
+	return "", errors.New("Failed to get current subscription from cli config")
+}
+
+func removeBOM(reader *bufio.Reader) error {
+	rune, _, err := reader.ReadRune()
+	if err != nil {
+		return fmt.Errorf("Error testing azure profile for BOM: %w", err)
+	}
+	if rune != BOM {
+		if err := reader.UnreadRune(); err != nil {
+			return fmt.Errorf("Failed to unread rune: %w", err)
+		}
+	}
+	return nil
+}
 func parseConnectionString(connString string) (name string, key string, err error) {
 	keyRegex := regexp.MustCompile("AccountKey=([^;]+)")
 	keyMatch := keyRegex.FindAllStringSubmatch(connString, -1)

--- a/pkg/azure/blob/credentials_test.go
+++ b/pkg/azure/blob/credentials_test.go
@@ -1,0 +1,132 @@
+package blob
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"get.porter.sh/plugin/azure/pkg/azure/azureconfig"
+	"github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGet_GetCredentials(t *testing.T) {
+	testcases := []struct {
+		name         string
+		envVarsToSet map[string]string
+		config       *azureconfig.Config
+		testfunc     func(t *testing.T, envVarsToSet map[string]string, config *azureconfig.Config, logger hclog.Logger)
+	}{
+		{
+			"Missing Environment Variables",
+			map[string]string{},
+			&azureconfig.Config{},
+			missingEnvironmentVariables,
+		},
+		{
+			"Invalid Connection string",
+			map[string]string{
+				"AZURE_STORAGE_CONNECTION_STRING": "Invalid",
+			},
+			&azureconfig.Config{},
+			invalidConnectionString,
+		},
+		{
+			"Valid Connection string",
+			map[string]string{
+				"AZURE_STORAGE_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=bmFtZQo=;AccountKey=a2V5Cg==;EndpointSuffix=core.windows.net",
+			},
+			&azureconfig.Config{},
+			validConnectionString,
+		},
+		{
+			"Missing Storage Acccount Resource Group",
+			map[string]string{},
+			&azureconfig.Config{
+				StorageAccount: "account",
+			},
+			missingStorageAccountResourceGroup,
+		},
+		{
+			"Missing Storage Acccount Name",
+			map[string]string{},
+			&azureconfig.Config{
+				StorageAccountResourceGroup: "group",
+			},
+			missingStorageAccountName,
+		},
+		{
+			"loginwithCLI",
+			map[string]string{},
+			&azureconfig.Config{
+				StorageAccount:              "account",
+				StorageAccountResourceGroup: "group",
+			},
+			loginwithCLI,
+		},
+	}
+	env := os.Environ()
+	for _, tc := range testcases {
+
+		t.Run(tc.name, func(t *testing.T) {
+
+			logger := hclog.New(&hclog.LoggerOptions{
+				Name:   strings.ReplaceAll(tc.name, " ", "_"),
+				Output: os.Stderr,
+				Level:  hclog.Error,
+			})
+
+			for k, v := range tc.envVarsToSet {
+				os.Setenv(k, v)
+			}
+
+			tc.testfunc(t, tc.envVarsToSet, tc.config, logger)
+			resetEnvironmentVars(t, env)
+		})
+	}
+}
+
+func resetEnvironmentVars(t *testing.T, env []string) {
+	os.Clearenv()
+	for _, e := range env {
+		pair := strings.Split(e, "=")
+		t.Logf("Resetting Env Variable: %s", pair[0])
+		os.Setenv(pair[0], pair[1])
+	}
+}
+
+func missingEnvironmentVariables(t *testing.T, envVarsToSet map[string]string, config *azureconfig.Config, logger hclog.Logger) {
+	_, err := GetCredentials(*config, logger)
+	assert.Error(t, err)
+	assert.True(t, strings.HasPrefix(err.Error(), "environment variable AZURE_STORAGE_CONNECTION_STRING containing the azure storage connection string was not set: StorageAccount and/or StorageAccountResourceGroup was not set, login with az cli not attempted"))
+}
+
+func invalidConnectionString(t *testing.T, envVarsToSet map[string]string, config *azureconfig.Config, logger hclog.Logger) {
+	_, err := GetCredentials(*config, logger)
+	assert.EqualError(t, err, "unexpected format for AZURE_STORAGE_CONNECTION_STRING, could not find AccountName=NAME and AccountKey=KEY in it")
+}
+
+func validConnectionString(t *testing.T, envVarsToSet map[string]string, config *azureconfig.Config, logger hclog.Logger) {
+	_, err := GetCredentials(*config, logger)
+	assert.NoError(t, err)
+}
+
+func missingStorageAccountResourceGroup(t *testing.T, envVarsToSet map[string]string, config *azureconfig.Config, logger hclog.Logger) {
+	_, err := GetCredentials(*config, logger)
+	assert.Error(t, err)
+	assert.True(t, strings.HasPrefix(err.Error(), "environment variable AZURE_STORAGE_CONNECTION_STRING containing the azure storage connection string was not set: StorageAccount and/or StorageAccountResourceGroup was not set, login with az cli not attempted"))
+}
+
+func missingStorageAccountName(t *testing.T, envVarsToSet map[string]string, config *azureconfig.Config, logger hclog.Logger) {
+	_, err := GetCredentials(*config, logger)
+	assert.Error(t, err)
+	assert.True(t, strings.HasPrefix(err.Error(), "environment variable AZURE_STORAGE_CONNECTION_STRING containing the azure storage connection string was not set: StorageAccount and/or StorageAccountResourceGroup was not set, login with az cli not attempted"))
+}
+
+func loginwithCLI(t *testing.T, envVarsToSet map[string]string, config *azureconfig.Config, logger hclog.Logger) {
+	_, err := GetCredentials(*config, logger)
+	if err != nil {
+		assert.True(t, strings.HasPrefix(err.Error(), "environment variable AZURE_STORAGE_CONNECTION_STRING containing the azure storage connection string was not set: Failed to get storage account keys:") || strings.HasPrefix(err.Error(), "environment variable AZURE_STORAGE_CONNECTION_STRING containing the azure storage connection string was not set: Failed to login with Azure cli:"))
+		return
+	}
+}

--- a/pkg/azure/blob/credentials_test.go
+++ b/pkg/azure/blob/credentials_test.go
@@ -1,7 +1,9 @@
 package blob
 
 import (
+	"fmt"
 	"os"
+	"path"
 	"strings"
 	"testing"
 
@@ -111,6 +113,20 @@ func Test_LoginwithCLI(t *testing.T) {
 		assert.Contains(t, err.Error(), "Failed to login with Azure CLI:")
 	}
 }
+func Test_ParseAzureProfile(t *testing.T) {
+
+	files := []string{"profile_with_bom.json", "profile_without_bom.json"}
+	for _, filename := range files {
+		testName := fmt.Sprintf("parsing %s", filename)
+		t.Run(testName, func(t *testing.T) {
+			testdata := path.Join("testdata", filename)
+			subscriptionId, err := getCurrentAzureSubscriptionFromProfile(testdata)
+			assert.NoError(t, err, "Expected no error parsing Azure Profile")
+			assert.Equal(t, "8b5ab980-0253-40d6-b22a-61b3f9d94491", subscriptionId, "Expected Subscription not found parsing Azure Profile")
+		})
+	}
+}
+
 func isLoggedInWithAzureCLI() bool {
 	_, err := cli.GetTokenFromCLI("https://management.azure.com/")
 	return err == nil

--- a/pkg/azure/blob/testdata/profile_with_bom.json
+++ b/pkg/azure/blob/testdata/profile_with_bom.json
@@ -1,0 +1,32 @@
+﻿{
+  "subscriptions": [
+    {
+      "id": "9c92af48-0841-40f6-8975-7113dafa2e6f",
+      "name": "Test Subscription 1",
+      "state": "Enabled",
+      "user": {
+        "name": "testuser@test.com",
+        "type": "user"
+      },
+      "isDefault": false,
+      "tenantId": "10ddd42b-6c5e-48f1-9285-60404c1a1335",
+      "environmentName": "AzureCloud",
+      "homeTenantId": "10ddd42b-6c5e-48f1-9285-60404c1a1335",
+      "managedByTenants": []
+    },
+    {
+      "id": "8b5ab980-0253-40d6-b22a-61b3f9d94491",
+      "name": "Test Subscription 2",
+      "state": "Enabled",
+      "user": {
+        "name": "testuser@test.com",
+        "type": "user"
+      },
+      "isDefault": true,
+      "tenantId": "10ddd42b-6c5e-48f1-9285-60404c1a1335",
+      "environmentName": "AzureCloud",
+      "homeTenantId": "10ddd42b-6c5e-48f1-9285-60404c1a1335",
+      "managedByTenants": []
+    }
+  ]
+}

--- a/pkg/azure/blob/testdata/profile_without_bom.json
+++ b/pkg/azure/blob/testdata/profile_without_bom.json
@@ -1,0 +1,32 @@
+{
+  "subscriptions": [
+    {
+      "id": "9c92af48-0841-40f6-8975-7113dafa2e6f",
+      "name": "Test Subscription 1",
+      "state": "Enabled",
+      "user": {
+        "name": "testuser@test.com",
+        "type": "user"
+      },
+      "isDefault": false,
+      "tenantId": "10ddd42b-6c5e-48f1-9285-60404c1a1335",
+      "environmentName": "AzureCloud",
+      "homeTenantId": "10ddd42b-6c5e-48f1-9285-60404c1a1335",
+      "managedByTenants": []
+    },
+    {
+      "id": "8b5ab980-0253-40d6-b22a-61b3f9d94491",
+      "name": "Test Subscription 2",
+      "state": "Enabled",
+      "user": {
+        "name": "testuser@test.com",
+        "type": "user"
+      },
+      "isDefault": true,
+      "tenantId": "10ddd42b-6c5e-48f1-9285-60404c1a1335",
+      "environmentName": "AzureCloud",
+      "homeTenantId": "10ddd42b-6c5e-48f1-9285-60404c1a1335",
+      "managedByTenants": []
+    }
+  ]
+}


### PR DESCRIPTION
This change adds support for Azure CLI based login to the storage plugin, using this mechanism removes the requirement to store or provide a connection string with an access key.

Details on usage in README.md