### PR TITLE
Use the updated plugin publish functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ test-recorder: build
 	$(RECORDTEST) test ./pkg/azure/table/...
 
 publish: bin/porter$(FILE_EXT)
-	go run mage.go -v Publish $(PLUGIN) $(VERSION) $(PERMALINK)
+	go run mage.go -v Publish
 
 bin/porter$(FILE_EXT):
 	curl -fsSLo bin/porter$(FILE_EXT) https://cdn.porter.sh/canary/porter-$(CLIENT_PLATFORM)-$(CLIENT_ARCH)$(FILE_EXT)

--- a/magefile.go
+++ b/magefile.go
@@ -4,12 +4,33 @@
 package main
 
 import (
+	
+	"fmt"
+	"os"
+
 	// mage:import
 	"get.porter.sh/magefiles/releases"
 )
 
-func Publish(plugin string) {
-	releases.PreparePluginForPublish(plugin)
-	releases.PublishPlugin(plugin)
-	releases.PublishPluginFeed(plugin)
+const (
+	pluginName = "azure"
+)
+
+// Publish the cross-compiled binaries.
+func Publish() {
+	releases.PublishPlugin(pluginName)
+	releases.PublishPluginFeed(pluginName)
+}
+
+// Test out publish locally, with your github forks
+// Assumes that you forked and kept the repository name unchanged.
+func TestPublish(username string) {
+	pluginRepo := fmt.Sprintf("github.com/%s/%s-plugins", username, pluginName)
+	pkgRepo := fmt.Sprintf("https://github.com/%s/packages.git", username)
+	fmt.Printf("Publishing a release to %s and committing a mixin feed to %s\n", pluginRepo, pkgRepo)
+	fmt.Printf("If you use different repository names, set %s and %s then call mage Publish instead.\n", releases.ReleaseRepository, releases.PackagesRemote)
+	os.Setenv(releases.ReleaseRepository, pluginRepo)
+	os.Setenv(releases.PackagesRemote, pkgRepo)
+
+	Publish()
 }


### PR DESCRIPTION
The publish step is failing on main. I've updated the publish function to use the updated plugin publish logic that we figured out when working on publish for the kubernetes mixin.