### PR TITLE
Prep plugin before publishing

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	
 	"fmt"
 	"os"
 
@@ -13,11 +12,13 @@ import (
 )
 
 const (
+	// Name of the plugin
 	pluginName = "azure"
 )
 
 // Publish the cross-compiled binaries.
 func Publish() {
+	releases.PreparePluginForPublish(pluginName)
 	releases.PublishPlugin(pluginName)
 	releases.PublishPluginFeed(pluginName)
 }


### PR DESCRIPTION
Since we haven't finished moving this plugin over to mage (coming soon), the xbuildall target isn't calling prepare plugin for publish yet.

So I've added that to the publish target before we attempt to publish.