### PR TITLE
Fix release lag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ replace (
 )
 
 require (
-	get.porter.sh/magefiles v0.5.0
+	get.porter.sh/magefiles v0.5.1
 	get.porter.sh/porter v1.0.10
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible
 	github.com/Azure/go-autorest/autorest v0.11.28

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,8 @@ cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RX
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3fOKtUw0Xmo=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-get.porter.sh/magefiles v0.5.0 h1:Hy/DgS0l+9TlEKcHKMPBCpzIRCKUs13wasT+T8S6P+A=
-get.porter.sh/magefiles v0.5.0/go.mod h1:KzKenKVauKKDhZ5FERVhqSz8m/xVSsRzOPseDA4UDIE=
+get.porter.sh/magefiles v0.5.1 h1:TUDxM/JoQjGnQ0YHxWr+Ko4Y8h/ETAMgW38jzN3fgBM=
+get.porter.sh/magefiles v0.5.1/go.mod h1:KzKenKVauKKDhZ5FERVhqSz8m/xVSsRzOPseDA4UDIE=
 get.porter.sh/porter v1.0.10 h1:7MhY2Bj+iXwBR/Y/iDZ8izLaeIpEr8a8OnR2lGqKmZs=
 get.porter.sh/porter v1.0.10/go.mod h1:73gEAO3f7W49kjHN/TOBQuhH9Cuop0woh2q8zsFAFhI=
 github.com/Azure/azure-sdk-for-go v68.0.0+incompatible h1:fcYLmCpyNYRnvJbPerq7U0hS+6+I79yEDJBqVNcqUzU=


### PR DESCRIPTION
Update to magefiles v0.5.1 which ensures that releases stay in draft until the assets are successfully uploaded.

Related to getporter/porter#2723